### PR TITLE
Fix event dates for the event on 2016-05-23

### DIFF
--- a/_posts/2016-05-23-blockchain.markdown
+++ b/_posts/2016-05-23-blockchain.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Treffen am Montag, den 23.05.2016 um 19 Uhr"
-date:   2016-05-23 19:00:00+02:00
+date:   2016-05-11 09:57:28+02:00
 event-date: 2016-05-23 19:00:00+02:00
 location: Technologiepark 13
 location-text: Konferenzraum B


### PR DESCRIPTION
The date header is the publishing date, dates in the future will cause a post not beeing published. The date of the event goes in the event-date header. This header was missing the timezone, which I fixed as well.